### PR TITLE
利用規約とプライバシーポリシーページの作成#20

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,5 +86,4 @@ group :test do
   gem "shoulda-matchers"
   gem "capybara"
   gem "selenium-webdriver"
-  gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.13.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -260,10 +260,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -300,7 +296,6 @@ DEPENDENCIES
   tzinfo-data
   view_component
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.1p31

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,7 @@
+class StaticPagesController < ApplicationController
+  def terms_of_service
+  end
+
+  def privacy_policy
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,2 @@
+<h1>プライバシーポリシー</h1>
+<p>Find me in app/views/static_pages/privacy_policy.html.erb</p>

--- a/app/views/static_pages/terms_of_service.html.erb
+++ b/app/views/static_pages/terms_of_service.html.erb
@@ -1,0 +1,2 @@
+<h1>利用規約</h1>
+<p>Find me in app/views/static_pages/terms_of_service.html.erb</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,13 @@ module PuchiUniverse
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # Don't generate system test files.
-    config.generators.system_tests = nil
+    config.generators do |g|
+      g.test_framework :rspec,
+        fixtures: false,
+        view_specs: false,
+        helper_specs: false,
+        routing_specs: false,
+        request_specs: false
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,7 @@ Rails.application.routes.draw do
   root "galleries#index"
   get 'galleries/index'
   get 'museums/index'
+
+  get 'terms_of_service', to: 'static_pages#terms_of_service'
+  get 'privacy_policy', to: 'static_pages#privacy_policy'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome
+  end
+end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "StaticPages", type: :system do
+  it "利用規約のページを取得できるか" do
+    get terms_of_service_url
+    expect(response).to have_http_status(:success)
+  end
+
+  it "プライバシーポリシーのページを取得できるか" do
+    get privacy_policy_url
+    expect(response).to have_http_status(:success)
+  end
+end


### PR DESCRIPTION
利用規約とプライバシーポリシーページのガワのみを作成(中身を今後作成予定)
rspecの設定を追加
ブラウザテストの設定を追加。それに伴い、selenium-webdriverとcapybaraのバージョンを上げる

    
    

