### PR TITLE
プロフィールの登録#27

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ group :development, :test do
 
   #[https://github.com/thoughtbot/factory_bot_rails]
   gem 'factory_bot_rails'
+
+  #[https://github.com/pry/pry-rails]
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     cssbundling-rails (1.2.0)
@@ -161,6 +162,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
@@ -298,6 +304,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.7, >= 7.0.7.2)
   rails-i18n (~> 7.0.0)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,26 @@
+class ProfilesController < ApplicationController
+  def new
+    @profile = Profile.new
+  end
+
+  def create
+    #profile_params = profile_params_with_date
+    @profile = Profile.new(profile_params)
+    if @profile.save
+      # プロフィール情報が正常に保存された場合の処理
+      redirect_to root_path, notice: "プロフィールが正常に保存されました"
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def profile_params
+    date_params = %w(birthday(1i) birthday(2i) birthday(3i))
+    birthdate = Date.new(params["profile"][date_params[0]].to_i, params["profile"][date_params[1]].to_i, params["profile"][date_params[2]].to_i)
+    params.require(:profile).permit(:name, :gender).merge(birthdate: birthdate)
+  end
+  
+  
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,9 +12,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    super do |resource|
+      redirect_to root_path # リダイレクト先を設定しないとテストが通らない
+      return
+    end
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    build_resource({})
+    resource.build_profile
+    respond_with resource
+  end
 
   # POST /resource
   # def create
@@ -38,12 +40,25 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
+
+  def sign_up_params
+    devise_parameter_sanitizer.sanitize(:sign_up) { |user| user.permit(permitted_attributes) }
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: permitted_attributes)
+  end
+
+  def permitted_attributes
+    [
+      :email,
+      :password,
+      :remember_me,
+      profile_attributes: %i[name birthdate gender]
+    ]
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,9 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+
+  enum gender: { male: 0, female: 1, other: 2, prefer_not_to_say: 3 }
+
+  validates :name, presence: true
+  validates :birthdate, presence: true
+  validates :gender, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_one :profile
+  has_one :profile, dependent: :destroy
 
   accepts_nested_attributes_for :profile
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_one :profile
+
+  accepts_nested_attributes_for :profile
+
 end

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,12 +4,11 @@
       <h1 class="text-3xl font-semibold text-center text-gray-700"><%= t 'defaults.signup' %></h1>
       <br>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-
+        <!-- メールアドレスとパスワードのフィールド -->
         <div class="field mb-5">
           <%= f.label :email %><br />
           <%= f.email_field :email, placeholder: (t '.Email Address'), class: "w-full input input-bordered", autofocus: true, autocomplete: "email" %>
         </div>
-
         <div class="field mb-5">
           <%= f.label :password %>
           <% if @minimum_password_length %>
@@ -18,17 +17,57 @@
           <%= f.password_field :password, placeholder: (t '.Password'), class: "w-full input input-bordered", autocomplete: "new-password" %>
         </div>
 
-        <div class="field mb-5">
-          <%= f.label :password_confirmation %><br />
-          <%= f.password_field :password_confirmation, placeholder: (t '.Password_confirmation'), class: "w-full input input-bordered", autocomplete: "new-password" %>
+        <!-- プロフィール情報のフィールド -->
+        <%= f.fields_for :profile do |profile_fields| %>
+          <div class="field mb-7">
+            <%= profile_fields.label :name %>
+            <%= profile_fields.text_field :name, class: "w-full input input-bordered" %>
+          </div>
+        <% end %>
+
+        <div>
+          <%= f.fields_for :profile do |profile_fields| %>
+            <div class="field mb-7">
+              <%= profile_fields.label :gender %>
+              <div class="flex mb-7"><!--genderのenumに基づいて表示-->
+                <% Profile.genders.keys.each do |gender| %>
+                  <div class="flex items-center mr-4">
+                    <%= profile_fields.radio_button :gender, gender, id: "gender-#{gender}" %>
+                    <%= profile_fields.label gender, class: "text-sm font-medium text-gray-900 ml-2 flex items-center" %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
         </div>
 
+        <%= f.fields_for :profile do |profile_fields| %>
+          <div class="field mb-7">
+            <div>
+              <%= profile_fields.label :birthdate %>
+            </div>
+            <div class="inline-flex space-x-3 w-full">
+              <%= profile_fields.date_select :birthdate,
+                {
+                  start_year: Time.now.year - 5,
+                  end_year: 1930,
+                  order: [:year, :month, :day],
+                  use_month_numbers: true,
+                  prompt: { year: '年', month: '月', day: '日' }
+                },
+                class: "btn btn-active btn-neutra flex-grow"
+              %>
+            </div>
+          </div>
+        <% end %>
+
+        <!-- 登録ボタン -->
         <div class="actions mb-7">
           <%= f.submit (t 'defaults.signup'), class: "btn btn-active btn-accent btn-block" %>
         </div>
 
         <hr class="mb-5">
-        <div class="text-center mb-5">
+        <div class="text-center mb-3">
           <a href="<%= new_user_session_path %>" class="text-base text-gray-600" ><%= t 'defaults.login'%></a>
         </div>
       <% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,60 +6,62 @@
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <!-- メールアドレスとパスワードのフィールド -->
         <div class="field mb-5">
-          <label for="user_email" class="font-semibold"><%= f.label :email %></label>
+          <%= f.label :email, class: "font-semibold", for: "user_email" %>
           <%= f.email_field :email, id: "user_email", class: "w-full input input-bordered", autofocus: true, autocomplete: "email" %>
         </div>
         <div class="field mb-5">
-          <label for="user_password" class="font-semibold"><%= f.label :password %></label>
-          <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %><%= t '.characters minimum'%>)</em>
-          <% end %>
+          <%= f.label :password, class: "font-semibold", for: "user_password" %>
+            <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %><%= t '.characters minimum'%>)</em>
+            <% end %>
           <%= f.password_field :password, class: "w-full input input-bordered", autocomplete: "new-password" %>
         </div>
 
         <!-- プロフィール情報のフィールド -->
         <%= f.fields_for :profile do |profile_fields| %>
           <div class="field mb-7">
-          <label for="user_name" class="font-semibold"><%= profile_fields.label :name %></label>
-            <%= profile_fields.text_field :name,id: "user_name", class: "w-full input input-bordered" %>
+            <%= profile_fields.label :name, class: "font-semibold", for: "user_name" %>
+            <%= profile_fields.text_field :name, id: "user_name", class: "w-full input input-bordered" %>
           </div>
         <% end %>
 
         <div>
           <%= f.fields_for :profile do |profile_fields| %>
-            <div class="field mb-7">
-              <label for="user_gender" class="font-semibold"><%= profile_fields.label :gender %></label>
+            <fieldset>
+              <legend style="font-weight: bold;" class="font-semibold"><%= t 'profile.gender.gender' %></legend>
               <div class="flex mb-7"><!--genderのenumに基づいて表示-->
                 <% Profile.genders.keys.each do |gender| %>
                   <div class="flex items-center mr-7">
                     <%= profile_fields.radio_button :gender, gender, id: "gender-#{gender}" %>
-                    <%= profile_fields.label gender, t("profile.gender.#{gender}"), class: "text-base font-medium text-gray-900 ml-1 flex items-center" %>
+                    <%= profile_fields.label gender, t("profile.gender.#{gender}"), for: "gender-#{gender}", class: "text-base font-medium text-gray-900 ml-1 flex items-center" %>
                   </div>
                 <% end %>
               </div>
-            </div>
+            </fieldset>
           <% end %>
         </div>
 
         <%= f.fields_for :profile do |profile_fields| %>
-          <div class="field mb-7">
-            <div>
-              <label for="user_name" class="font-semibold"><%= profile_fields.label :birthdate %></label>
+          <fieldset>
+            <div class="field mb-7">
+              <div>
+                <legend style="font-weight: bold;" class="font-semibold"><%= t 'profile.date.birthdate' %></legend>
+              </div>
+              <div class="inline-flex space-x-3 w-full">
+                <%= profile_fields.date_select :birthdate,
+                  {
+                    start_year: Time.now.year - 5,
+                    end_year: 1930,
+                    order: [:year, :month, :day],
+                    use_month_numbers: true,
+                    prompt: { year: t('date.prompts.year'), month: t('date.prompts.month'), day: t('date.prompts.day') },
+                    id: "user_birthdate"
+                  },
+                  class: "btn btn-active btn-neutra flex-grow"
+                %>
+              </div>
             </div>
-            <div class="inline-flex space-x-3 w-full">
-              <%= profile_fields.date_select :birthdate,
-                {
-                  start_year: Time.now.year - 5,
-                  end_year: 1930,
-                  order: [:year, :month, :day],
-                  use_month_numbers: true,
-                  prompt: { year: t('date.prompts.year'), month: t('date.prompts.month'), day: t('date.prompts.day') },
-                  id: "user_birthdate"
-                },
-                class: "btn btn-active btn-neutra flex-grow"
-              %>
-            </div>
-          </div>
+          </fieldset>
         <% end %>
 
         <!-- 登録ボタン -->
@@ -69,7 +71,7 @@
 
         <hr class="mb-5">
         <div class="text-center mb-3">
-          <%=link_to(t('defaults.login'), new_user_session_path, class: 'text-base text-gray-600') %>
+          <%= link_to(t('defaults.login'), new_user_session_path, class: 'text-base text-gray-600') %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,34 +6,34 @@
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <!-- メールアドレスとパスワードのフィールド -->
         <div class="field mb-5">
-          <%= f.label :email %><br />
-          <%= f.email_field :email, placeholder: (t '.Email Address'), class: "w-full input input-bordered", autofocus: true, autocomplete: "email" %>
+          <label for="user_email" class="font-semibold"><%= f.label :email %></label>
+          <%= f.email_field :email, id: "user_email", class: "w-full input input-bordered", autofocus: true, autocomplete: "email" %>
         </div>
         <div class="field mb-5">
-          <%= f.label :password %>
+          <label for="user_password" class="font-semibold"><%= f.label :password %></label>
           <% if @minimum_password_length %>
           <em>(<%= @minimum_password_length %><%= t '.characters minimum'%>)</em>
-          <% end %><br />
-          <%= f.password_field :password, placeholder: (t '.Password'), class: "w-full input input-bordered", autocomplete: "new-password" %>
+          <% end %>
+          <%= f.password_field :password, class: "w-full input input-bordered", autocomplete: "new-password" %>
         </div>
 
         <!-- プロフィール情報のフィールド -->
         <%= f.fields_for :profile do |profile_fields| %>
           <div class="field mb-7">
-            <%= profile_fields.label :name %>
-            <%= profile_fields.text_field :name, class: "w-full input input-bordered" %>
+          <label for="user_name" class="font-semibold"><%= profile_fields.label :name %></label>
+            <%= profile_fields.text_field :name,id: "user_name", class: "w-full input input-bordered" %>
           </div>
         <% end %>
 
         <div>
           <%= f.fields_for :profile do |profile_fields| %>
             <div class="field mb-7">
-              <%= profile_fields.label :gender %>
+              <label for="user_gender" class="font-semibold"><%= profile_fields.label :gender %></label>
               <div class="flex mb-7"><!--genderのenumに基づいて表示-->
                 <% Profile.genders.keys.each do |gender| %>
-                  <div class="flex items-center mr-4">
+                  <div class="flex items-center mr-7">
                     <%= profile_fields.radio_button :gender, gender, id: "gender-#{gender}" %>
-                    <%= profile_fields.label gender, class: "text-sm font-medium text-gray-900 ml-2 flex items-center" %>
+                    <%= profile_fields.label gender, t("profile.gender.#{gender}"), class: "text-base font-medium text-gray-900 ml-1 flex items-center" %>
                   </div>
                 <% end %>
               </div>
@@ -44,7 +44,7 @@
         <%= f.fields_for :profile do |profile_fields| %>
           <div class="field mb-7">
             <div>
-              <%= profile_fields.label :birthdate %>
+              <label for="user_name" class="font-semibold"><%= profile_fields.label :birthdate %></label>
             </div>
             <div class="inline-flex space-x-3 w-full">
               <%= profile_fields.date_select :birthdate,
@@ -53,7 +53,8 @@
                   end_year: 1930,
                   order: [:year, :month, :day],
                   use_month_numbers: true,
-                  prompt: { year: '年', month: '月', day: '日' }
+                  prompt: { year: t('date.prompts.year'), month: t('date.prompts.month'), day: t('date.prompts.day') },
+                  id: "user_birthdate"
                 },
                 class: "btn btn-active btn-neutra flex-grow"
               %>
@@ -68,7 +69,7 @@
 
         <hr class="mb-5">
         <div class="text-center mb-3">
-          <a href="<%= new_user_session_path %>" class="text-base text-gray-600" ><%= t 'defaults.login'%></a>
+          <%=link_to(t('defaults.login'), new_user_session_path, class: 'text-base text-gray-600') %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -14,7 +14,7 @@
             <% if @minimum_password_length %>
             <em>(<%= @minimum_password_length %><%= t '.characters minimum'%>)</em>
             <% end %>
-          <%= f.password_field :password, class: "w-full input input-bordered", autocomplete: "new-password" %>
+          <%= f.password_field :password, id: "user_password", class: "w-full input input-bordered", autocomplete: "new-password" %>
         </div>
 
         <!-- プロフィール情報のフィールド -->
@@ -32,8 +32,8 @@
               <div class="flex mb-7"><!--genderのenumに基づいて表示-->
                 <% Profile.genders.keys.each do |gender| %>
                   <div class="flex items-center mr-7">
-                    <%= profile_fields.radio_button :gender, gender, id: "gender-#{gender}" %>
-                    <%= profile_fields.label gender, t("profile.gender.#{gender}"), for: "gender-#{gender}", class: "text-base font-medium text-gray-900 ml-1 flex items-center" %>
+                    <%= profile_fields.radio_button :gender, gender, id: "gender_#{gender}" %>
+                    <%= profile_fields.label gender, t("profile.gender.#{gender}"), for: "gender_#{gender}", class: "text-base font-medium text-gray-900 ml-1 flex items-center" %>
                   </div>
                 <% end %>
               </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -6,13 +6,13 @@
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
         <div class="field mb-5">
-          <%= f.label :email %><br />
-          <%= f.email_field :email, placeholder: (t '.Email Address'), class: "w-full input input-bordered", autofocus: true, autocomplete: "email" %>
+        <label for="user_email" class="font-semibold"><%= f.label :email %></label>
+          <%= f.email_field :email, class: "w-full input input-bordered", autofocus: true, autocomplete: "email" %>
         </div>
 
         <div class="field mb-5">
-          <%= f.label :password %><br />
-          <%= f.password_field :password, placeholder: (t '.Password'), class: "w-full input input-bordered", autocomplete: "current-password" %>
+        <label for="user_password" class="font-semibold"><%= f.label :password %></label>
+          <%= f.password_field :password, class: "w-full input input-bordered", autocomplete: "current-password" %>
         </div>
 
         <% if devise_mapping.rememberable? %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -6,5 +6,13 @@ ja:
       user:
         email: 'メールアドレス'
         password: 'パスワード'
-        password_confirmation: '確認用パスワード'
         remember_me: '次回から自動的にログイン'
+      profile:
+        name: 'ユーザー名'
+        gender: '性別'
+        birthdate: '生年月日'
+  date:
+    prompts:
+      day: '日'
+      month: '月'
+      year: '年'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,20 +4,18 @@ ja:
     login: 'ログイン'
     logout: 'ログアウト'
   users:
-    sessions:
-      new:
-        Email Address: 'メールアドレス'
-        Password: 'パスワード'
     registrations:
       new:
-        Email Address: 'メールアドレス'
-        Password: 'パスワード'
-        Password_confirmation: '確認用パスワード'
         characters minimum: '文字以上'
   static_pages:
     terms_of_service:
       terms_of_service: '利用規約'
     privacy_policy:
       privacy_policy: 'プライバシーポリシー'
-    
+  profile:
+    gender:
+      male: '男性'
+      female: '女性'
+      other: 'その他'
+      prefer_not_to_say: '無回答'
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,9 +13,14 @@ ja:
     privacy_policy:
       privacy_policy: 'プライバシーポリシー'
   profile:
+    name: 'ユーザー名'
+  profile:
     gender:
+      gender: '性別'
       male: '男性'
       female: '女性'
       other: 'その他'
       prefer_not_to_say: '無回答'
+    date:
+      birthdate: '生年月日'
 

--- a/db/migrate/20231023022546_create_profiles.rb
+++ b/db/migrate/20231023022546_create_profiles.rb
@@ -1,0 +1,11 @@
+class CreateProfiles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :profiles do |t|
+      t.string :name, null: false
+      t.date :birthdate, null: false
+      t.string :gender, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231026125857_add_user_id_to_profiles.rb
+++ b/db/migrate/20231026125857_add_user_id_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddUserIdToProfiles < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :profiles, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20231101040539_change_gender_column_type_in_profiles.rb
+++ b/db/migrate/20231101040539_change_gender_column_type_in_profiles.rb
@@ -1,0 +1,6 @@
+class ChangeGenderColumnTypeInProfiles < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :profiles, :gender, :string
+    add_column :profiles, :gender, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_07_090807) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_26_125857) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "profiles", force: :cascade do |t|
+    t.string "name", null: false
+    t.date "birthdate", null: false
+    t.string "gender", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +36,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_07_090807) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_26_125857) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_01_040539) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "profiles", force: :cascade do |t|
     t.string "name", null: false
     t.date "birthdate", null: false
-    t.string "gender", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.integer "gender", null: false
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :profile do
+    
+  end
+end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :profile do
-    
+    name { "john" }
+    gender { "male" }
+    birthdate { Date.new(2012, 1, 2) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user_#{n}@example.com" }
     password { "password" }
-    password_confirmation { "password" }
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Profile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'ユーザー登録' do
-    it "email、password、password_confirmationでユーザー登録ができる" do
+    it "email、password、ユーザー名、性別、生年月日でユーザー登録ができる" do
       user = build(:user)
+      profile = build(:profile)
+      user.profile = profile
       expect(user).to be_valid  # user.valid? が true になればパスする
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  let(:user) { create(:user) }
+  let(:profile) { create(:profile, user: user) }
+
+  scenario "新規ユーザー登録ができる" do
+    visit root_path
+    find('label[for="my-drawer-3"].btn.btn-square.btn-ghost').click #ハンバーガーアイコンをクリック
+    click_link "アカウントを作成"
+    fill_in "メールアドレス", with: user.email
+    fill_in "パスワード", with: user.password
+    fill_in "ユーザー名", with: profile.name
+    choose("gender-male")
+
+    # 誕生日の入力
+    select '2012', from: 'user_profile_attributes_birthdate_1i' # 年を選択
+    select '1', from: 'user_profile_attributes_birthdate_2i'     # 月を選択
+    select '2', from: 'user_profile_attributes_birthdate_3i'    # 日を選択
+
+    click_button "アカウントを作成" 
+
+    expect(page).to have_current_path(root_path)
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Users", type: :system do
     fill_in "メールアドレス", with: user.email
     fill_in "パスワード", with: user.password
     fill_in "ユーザー名", with: profile.name
-    choose("gender-male")
+    choose("gender_male")
 
     # 誕生日の入力
     select '2012', from: 'user_profile_attributes_birthdate_1i' # 年を選択


### PR DESCRIPTION
アカウント登録時に、名前、性別、生年月日の項目を追加
名前、性別、生年月日はprofileカラムで管理する。また、user削除時には紐づいたprofileも削除するように`dependent: :destroy`を指定する

性別のカラムをstringからintegerに変更し、enumに対応させる

テストを作成。リダイレクト先を指定することによりテストをパス