### PR TITLE
スケール比較写真の作成機能を実装#38

### DIFF
--- a/app/controllers/scale_comparison_photos_controller.rb
+++ b/app/controllers/scale_comparison_photos_controller.rb
@@ -19,6 +19,6 @@ class ScaleComparisonPhotosController < ApplicationController
   private
 
   def scale_comparison_photo_params
-    params.require(:scale_comparison_photo).permit(:product_name, :company, :kinds, :contents)
+    params.require(:scale_comparison_photo).permit(:product_name, :company, :kind, :content)
   end
 end

--- a/app/controllers/scale_comparison_photos_controller.rb
+++ b/app/controllers/scale_comparison_photos_controller.rb
@@ -2,4 +2,23 @@ class ScaleComparisonPhotosController < ApplicationController
   def index
     @scale_comparison_photos = ScaleComparisonPhoto.all.order(created_at: :desc)
   end
+
+  def new
+    @scale_comparison_photo = ScaleComparisonPhoto.new
+  end
+
+  def create
+    @scale_comparison_photo = current_user.scale_comparison_photos.build(scale_comparison_photo_params)
+    if @scale_comparison_photo.save
+      redirect_to museums_path, flash: { success: t('defaults.message.created') }
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def scale_comparison_photo_params
+    params.require(:scale_comparison_photo).permit(:product_name, :company)
+  end
 end

--- a/app/controllers/scale_comparison_photos_controller.rb
+++ b/app/controllers/scale_comparison_photos_controller.rb
@@ -19,6 +19,6 @@ class ScaleComparisonPhotosController < ApplicationController
   private
 
   def scale_comparison_photo_params
-    params.require(:scale_comparison_photo).permit(:product_name, :company)
+    params.require(:scale_comparison_photo).permit(:product_name, :company, :kinds, :contents)
   end
 end

--- a/app/controllers/scale_comparison_photos_controller.rb
+++ b/app/controllers/scale_comparison_photos_controller.rb
@@ -1,5 +1,5 @@
 class ScaleComparisonPhotosController < ApplicationController
   def index
-    @scale_comparison_photos = ScaleComparisonPhoto.includes(:tag).all.order(created_at: :desc)
+    @scale_comparison_photos = ScaleComparisonPhoto.all.order(created_at: :desc)
   end
 end

--- a/app/models/scale_comparison_photo.rb
+++ b/app/models/scale_comparison_photo.rb
@@ -1,4 +1,5 @@
 class ScaleComparisonPhoto < ApplicationRecord
-  belongs_to :tag
   belongs_to :user
+
+  validates :product_name, presence: true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,3 @@
 class Tag < ApplicationRecord
-  has_one :scale_comparison_photo
-
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/views/scale_comparison_photos/_form.html.erb
+++ b/app/views/scale_comparison_photos/_form.html.erb
@@ -8,6 +8,18 @@
     <%= f.text_field :company, id: "scale_comparison_photo_company", class: 'w-full bg-gray-100 border border-gray-300 p-2 mb-4 outline-none' %>
   </div>
 
+  <div class="field mb-5">
+    <%= f.label :kinds, class: 'font-medium', for: "scale_comparison_photo_kinds" %>
+    <div>
+      <%= f.select :kinds, (1..20).to_a, {}, { id: "scale_comparison_photo_kinds", class: 'w-1/3 bg-gray-100 border border-gray-300 p-2 mb-4 outline-none' } %>
+    </div>
+  </div>
+
+  <div class="field mb-5">
+    <%= f.label :contents, class: 'font-medium', for: "scale_comparison_photo_contents" %>
+    <%= f.text_area :contents, id: "scale_comparison_photo_contents", class: 'w-full bg-gray-100 sec p-3 h-60 border border-gray-300 outline-none' %>
+  </div>
+
   <!-- Buttons -->
   <div class="actions mb-7 text-center">
     <%= f.submit (t '.new.post'), class: "btn btn-active btn-accent" %>

--- a/app/views/scale_comparison_photos/_form.html.erb
+++ b/app/views/scale_comparison_photos/_form.html.erb
@@ -1,0 +1,15 @@
+<%= form_with model: ScaleComparisonPhoto.new, url: museums_create_path do |f| %>
+  <div class="field mb-5">
+    <%= f.label :product_name, class: 'font-medium', for: "scale_comparison_photo_product_name" %>
+    <%= f.text_field :product_name, id: "scale_comparison_photo_product_name", class: 'w-full bg-gray-100 border border-gray-300 p-2 mb-4 outline-none' %>
+  </div>
+  <div class="field mb-5">
+    <%= f.label :company, class: 'font-medium', for: "scale_comparison_photo_company" %>
+    <%= f.text_field :company, id: "scale_comparison_photo_company", class: 'w-full bg-gray-100 border border-gray-300 p-2 mb-4 outline-none' %>
+  </div>
+
+  <!-- Buttons -->
+  <div class="actions mb-7 text-center">
+    <%= f.submit (t '.new.post'), class: "btn btn-active btn-accent" %>
+  </div>
+<% end %>

--- a/app/views/scale_comparison_photos/_form.html.erb
+++ b/app/views/scale_comparison_photos/_form.html.erb
@@ -9,15 +9,15 @@
   </div>
 
   <div class="field mb-5">
-    <%= f.label :kinds, class: 'font-medium', for: "scale_comparison_photo_kinds" %>
+    <%= f.label :kind, class: 'font-medium', for: "scale_comparison_photo_kind" %>
     <div>
-      <%= f.select :kinds, (1..20).to_a, {}, { id: "scale_comparison_photo_kinds", class: 'w-1/3 bg-gray-100 border border-gray-300 p-2 mb-4 outline-none' } %>
+      <%= f.select :kind, (1..20).to_a, {}, { id: "scale_comparison_photo_kind", class: 'w-1/3 bg-gray-100 border border-gray-300 p-2 mb-4 outline-none' } %>
     </div>
   </div>
 
   <div class="field mb-5">
-    <%= f.label :contents, class: 'font-medium', for: "scale_comparison_photo_contents" %>
-    <%= f.text_area :contents, id: "scale_comparison_photo_contents", class: 'w-full bg-gray-100 sec p-3 h-60 border border-gray-300 outline-none' %>
+    <%= f.label :content, class: 'font-medium', for: "scale_comparison_photo_content" %>
+    <%= f.text_area :content, id: "scale_comparison_photo_content", class: 'w-full bg-gray-100 sec p-3 h-60 border border-gray-300 outline-none' %>
   </div>
 
   <!-- Buttons -->

--- a/app/views/scale_comparison_photos/_scale_comparison_photo.html.erb
+++ b/app/views/scale_comparison_photos/_scale_comparison_photo.html.erb
@@ -2,7 +2,7 @@
   <img class="object-cover w-60 h-60 rounded-lg " src="https://images.unsplash.com/photo-1515378960530-7c0da6231fb1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80" alt="">
     <div class="flex flex-col justify-start py-8 sm:mx-6">
       <a href="#" class="text-xl font-semibold  text-gray-800 mb-2" >
-        <%= scale_comparison_photo.tag.name %>
+        <%= scale_comparison_photo.product_name %>
       </a>
       <div class="mb-2">
         <%= scale_comparison_photo.company %>

--- a/app/views/scale_comparison_photos/new.html.erb
+++ b/app/views/scale_comparison_photos/new.html.erb
@@ -1,0 +1,7 @@
+<body>
+  <div class="relative flex flex-col justify-center min-h-0 overflow-hidden">
+    <div class="w-full p-6 sm:max-w-lg md:max-w-xl lg:max-w-2xl mx-auto">
+      <%= render 'form', { scale_comparison_photo: @scalecomparisonphoto } %>
+    </div>
+  </div>
+</body>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,6 +24,7 @@
 
                 <% if current_user %>
                   <%= link_to t('scene_photos.new.create'), galleries_new_path, class: 'btn btn-ghost' %>
+                  <%= link_to t('scale_comparison_photos.new.create'), museums_new_path, class: 'btn btn-ghost' %>
                   <hr class="mb-5 mt-5">
                   <%= button_to (t 'defaults.logout'), destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-block', id: 'logout-button' %>
                 <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -14,6 +14,9 @@ ja:
       scene_photo:
         title: 'タイトル'
         caption: 'キャプション'
+      scale_comparison_photo:
+        product_name: '商品名'
+        company: '販売元'
   date:
     prompts:
       day: '日'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -17,8 +17,8 @@ ja:
       scale_comparison_photo:
         product_name: '商品名'
         company: '販売元'
-        kinds: '種類'
-        contents: '内容'
+        kind: '種類'
+        content: '内容'
   date:
     prompts:
       day: '日'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -17,6 +17,8 @@ ja:
       scale_comparison_photo:
         product_name: '商品名'
         company: '販売元'
+        kinds: '種類'
+        contents: '内容'
   date:
     prompts:
       day: '日'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,3 +40,8 @@ ja:
   scale_comparison_photos:
     index:
       no_result: '検索結果:該当なし'
+    new:
+      create: '博物館に投稿'
+    form:
+      new:
+        post: '投稿する'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get '/galleries/new', to: 'scene_photos#new'
   post '/galleries/create', to: 'scene_photos#create'
   get '/museums', to: 'scale_comparison_photos#index', as: 'museums'
+  get '/museums/new', to: 'scale_comparison_photos#new'
+  post '/museums/create', to: 'scale_comparison_photos#create'
 
   get 'terms_of_service', to: 'static_pages#terms_of_service'
   get 'privacy_policy', to: 'static_pages#privacy_policy'

--- a/db/migrate/20231126095130_add_product_name_to_scale_comparison_photos.rb
+++ b/db/migrate/20231126095130_add_product_name_to_scale_comparison_photos.rb
@@ -1,0 +1,6 @@
+class AddProductNameToScaleComparisonPhotos < ActiveRecord::Migration[7.0]
+  def change
+    add_column :scale_comparison_photos, :product_name, :string, null: false
+    remove_column :scale_comparison_photos, :tag_id
+  end
+end

--- a/db/migrate/20231127141129_add_kinds_and_contents_to_scale_comparison_photos.rb
+++ b/db/migrate/20231127141129_add_kinds_and_contents_to_scale_comparison_photos.rb
@@ -1,0 +1,6 @@
+class AddKindsAndContentsToScaleComparisonPhotos < ActiveRecord::Migration[7.0]
+  def change
+    add_column :scale_comparison_photos, :kinds, :integer
+    add_column :scale_comparison_photos, :contents, :text
+  end
+end

--- a/db/migrate/20231128125112_change_column_names_in_scale_comparison_photos.rb
+++ b/db/migrate/20231128125112_change_column_names_in_scale_comparison_photos.rb
@@ -1,0 +1,11 @@
+class ChangeColumnNamesInScaleComparisonPhotos < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :scale_comparison_photos, :kinds, :kind
+    rename_column :scale_comparison_photos, :contents, :content
+  end
+
+  def down
+    rename_column :scale_comparison_photos, :kind, :kinds
+    rename_column :scale_comparison_photos, :content, :contents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_26_095130) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_27_141129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,6 +30,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_26_095130) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.string "product_name", null: false
+    t.integer "kinds"
+    t.text "contents"
     t.index ["user_id"], name: "index_scale_comparison_photos_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_27_141129) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_28_125112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,8 +30,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_141129) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.string "product_name", null: false
-    t.integer "kinds"
-    t.text "contents"
+    t.integer "kind"
+    t.text "content"
     t.index ["user_id"], name: "index_scale_comparison_photos_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_15_132434) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_26_095130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,11 +26,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_15_132434) do
 
   create_table "scale_comparison_photos", force: :cascade do |t|
     t.string "company"
-    t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index ["tag_id"], name: "index_scale_comparison_photos_on_tag_id"
+    t.string "product_name", null: false
     t.index ["user_id"], name: "index_scale_comparison_photos_on_user_id"
   end
 
@@ -63,7 +62,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_15_132434) do
   end
 
   add_foreign_key "profiles", "users"
-  add_foreign_key "scale_comparison_photos", "tags"
   add_foreign_key "scale_comparison_photos", "users"
   add_foreign_key "scene_photos", "users"
 end


### PR DESCRIPTION
テーブル設計の見直し
（scale comparison tableに、product_name,kinds,contentsのカラムを追加。tagテーブルとの関連を削除）

スケール比較写真の入力フォームを作成。手動での投稿を確認